### PR TITLE
Fix for unicode errors on Python 3.x for Windows

### DIFF
--- a/PyLotROLauncher/PyLotROUtils.py
+++ b/PyLotROLauncher/PyLotROUtils.py
@@ -40,11 +40,11 @@ import ssl
 # Python 3 on windows needs Turbine-supplied config files
 # to be written in UTF-8, but Python 2 doesn't, and won't
 # convert an ascii string for use in codecs.open()
-if sys.version_info > (2,):
-	import codecs
-	uopen = codecs.open
+if sys.version_info >= (3,):
+	from codecs import open as uopen
 else:
-	uopen = open
+	def uopen(name, mode, dummy):
+		return open(name, mode)
 
 # If Python >3.0 is in use use http otherwise httplib
 # Python >3.0 uses unicode strings by default, so also
@@ -252,7 +252,7 @@ class DetermineOS:
 				os.environ["FONT_ENCODINGS_DIRECTORY"] = (cxPath + "/Contents/SharedSupport/X11/lib/" +
 					"X11/fonts/encodings/encodings.dir")
 				os.environ["FONTCONFIG_ROOT"] = "%s/Contents/SharedSupport/X11" % (cxPath)
-				os.environ["COMMAND_MODE"] = "legacy"
+				os.environ["COMMAND_MODE"] = "legacy" 
 				os.environ["FONTCONFIG_PATH"] = "%s/Contents/SharedSupport/X11/etc/fonts" % (cxPath)
 				os.environ["DYLD_FALLBACK_LIBRARY_PATH"] = (cxPath + "/Contents/SharedSupport/X11/lib" +
 					":" + os.environ.get('HOME') + "/lib:/usr/local/lib:/lib:/usr/lib")
@@ -266,7 +266,7 @@ class DetermineOS:
 					display = "2"
 				os.environ["DISPLAY"] = ":%s" % (display)
 
-		return finished
+		return finished			
 
 	def startCXO(self):
 		finished = True
@@ -309,7 +309,7 @@ class DetermineOS:
 				os.environ["FONT_ENCODINGS_DIRECTORY"] = (cxPath + "/Contents/SharedSupport/X11/lib/" +
 					"X11/fonts/encodings/encodings.dir")
 				os.environ["FONTCONFIG_ROOT"] = "%s/Contents/SharedSupport/X11" % (cxPath)
-				os.environ["COMMAND_MODE"] = "legacy"
+				os.environ["COMMAND_MODE"] = "legacy" 
 				os.environ["FONTCONFIG_PATH"] = "%s/Contents/SharedSupport/X11/etc/fonts" % (cxPath)
 				os.environ["DYLD_FALLBACK_LIBRARY_PATH"] = (cxPath + "/Contents/SharedSupport/X11/lib" +
 					":" + os.environ.get('HOME') + "/lib:/usr/local/lib:/lib:/usr/lib")
@@ -323,7 +323,7 @@ class DetermineOS:
 					display = "2"
 				os.environ["DISPLAY"] = ":%s" % (display)
 
-		return finished
+		return finished			
 
 class GLSDataCentre:
 	def __init__(self, urlGLSDataCentreService, gameName, baseDir, osType):
@@ -391,16 +391,14 @@ class Language:
 		if code == "EN_GB":
 			self.name = "English (UK)"
 			self.code = "ENGLISH"
-			self.news = "en"
-		elif code == "ENGLISH" or code == "en":
+		elif code == "ENGLISH":
 			self.name = "English"
 			self.code = "ENGLISH"
-			self.news = "en"
-		elif code == "FR" or code == "fr":
+		elif code == "FR":
 			self.name = "French"
 			self.code = "FR"
 			self.news = "fr"
-		elif code == "DE" or code == "de":
+		elif code == "DE":
 			self.name = "German"
 			self.code = "DE"
 			self.news = "de"
@@ -418,12 +416,6 @@ class LanguageConfig():
 			# remove "client_local_" (13 chars) and ".dat" (4 chars) from filename
 			temp = os.path.basename(name)[13:-4]
 			self.langList.append(Language(temp))
-		# Handle newer clients where the language is a subdir
-		for name in os.listdir(runDir):
-			lang = Language(name)
-			if lang.news != "":
-				self.langList.append(lang)
-				self.langFound = True
 
 class Realm:
 	def __init__(self, name, urlChatServer, urlServerStatus):
@@ -517,17 +509,17 @@ class WorldQueueConfig:
 						elif node.getAttribute("key") == "GameClient.WIN32.ArgTemplate":
 							self.gameClientArgTemplate = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.crashreceiver":
-							self.crashreceiver = node.getAttribute("value")
+						        self.crashreceiver = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.DefaultUploadThrottleMbps":
-							self.DefaultUploadThrottleMbps = node.getAttribute("value")
+						        self.DefaultUploadThrottleMbps = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.bugurl":
-							self.bugurl = node.getAttribute("value")
+						        self.bugurl = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.authserverurl":
-							self.authserverurl = node.getAttribute("value")
+						        self.authserverurl = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.supporturl":
-							self.supporturl = node.getAttribute("value")
+						        self.supporturl = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.supportserviceurl":
-							self.supportserviceurl = node.getAttribute("value")
+						        self.supportserviceurl = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.glsticketlifetime":
 							self.glsticketlifetime = node.getAttribute("value")
 						elif node.getAttribute("key") == "URL.NewsFeed":

--- a/PyLotROLauncher/PyLotROUtils.py
+++ b/PyLotROLauncher/PyLotROUtils.py
@@ -509,17 +509,17 @@ class WorldQueueConfig:
 						elif node.getAttribute("key") == "GameClient.WIN32.ArgTemplate":
 							self.gameClientArgTemplate = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.crashreceiver":
-						        self.crashreceiver = node.getAttribute("value")
+							self.crashreceiver = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.DefaultUploadThrottleMbps":
-						        self.DefaultUploadThrottleMbps = node.getAttribute("value")
+							self.DefaultUploadThrottleMbps = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.bugurl":
-						        self.bugurl = node.getAttribute("value")
+							self.bugurl = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.authserverurl":
-						        self.authserverurl = node.getAttribute("value")
+							self.authserverurl = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.supporturl":
-						        self.supporturl = node.getAttribute("value")
+							self.supporturl = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.supportserviceurl":
-						        self.supportserviceurl = node.getAttribute("value")
+							self.supportserviceurl = node.getAttribute("value")
 						elif node.getAttribute("key") == "GameClient.Arg.glsticketlifetime":
 							self.glsticketlifetime = node.getAttribute("value")
 						elif node.getAttribute("key") == "URL.NewsFeed":

--- a/PyLotROLauncher/PyLotROUtils.py
+++ b/PyLotROLauncher/PyLotROUtils.py
@@ -37,6 +37,15 @@ import xml.dom.minidom
 from xml.sax.saxutils import escape as xml_escape
 import ssl
 
+# Python 3 on windows needs Turbine-supplied config files
+# to be written in UTF-8, but Python 2 doesn't, and won't
+# convert an ascii string for use in codecs.open()
+if sys.version_info > (2,):
+	import codecs
+	uopen = codecs.open
+else:
+	uopen = open
+
 # If Python >3.0 is in use use http otherwise httplib
 # Python >3.0 uses unicode strings by default, so also
 # need to take care of encoding/decoding for sending/receiving
@@ -341,7 +350,7 @@ class GLSDataCentre:
 			tempxml = string_decode(webresp.read())
 
 			filename = "%s%sGLSDataCenter.config" % (baseDir, osType.appDir)
-			outfile = codecs.open(filename, "w", "utf-8")
+			outfile = uopen(filename, "w", "utf-8")
 			outfile.write(tempxml)
 			outfile.close()
 
@@ -430,7 +439,7 @@ class Realm:
 			tempxml = string_decode(webresp.read())
 
 			filename = "%s%sserver.config" % (baseDir, osType.appDir)
-			outfile = codecs.open(filename, "w", "utf-8")
+			outfile = uopen(filename, "w", "utf-8")
 			outfile.write(tempxml)
 			outfile.close()
 
@@ -483,7 +492,7 @@ class WorldQueueConfig:
 			tempxml = string_decode(webresp.read())
 
 			filename = "%s%slauncher.config" % (baseDir, osType.appDir)
-			outfile = codecs.open(filename, "w", "utf-8")
+			outfile = uopen(filename, "w", "utf-8")
 			outfile.write(tempxml)
 			outfile.close()
 
@@ -570,7 +579,7 @@ xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\
 			tempxml = string_decode(webresp.read())
 
 			filename = "%s%sGLSAuthServer.config" % (baseDir, osType.appDir)
-			outfile = codecs.open(filename, "w", "utf-8")
+			outfile = uopen(filename, "w", "utf-8")
 			outfile.write(tempxml)
 			outfile.close()
 
@@ -636,7 +645,7 @@ class JoinWorldQueue:
 			tempxml = string_decode(webresp.read())
 
 			filename = "%s%sWorldQueue.config" % (baseDir, osType.appDir)
-			outfile = codecs.open(filename, "w", "utf-8")
+			outfile = uopen(filename, "w", "utf-8")
 			outfile.write(tempxml)
 			outfile.close()
 

--- a/PyLotROLauncher/PyLotROUtils.py
+++ b/PyLotROLauncher/PyLotROUtils.py
@@ -31,6 +31,7 @@ import os
 import subprocess
 import sys
 import glob
+import codecs
 from PyQt4 import QtCore
 import xml.dom.minidom
 from xml.sax.saxutils import escape as xml_escape
@@ -340,7 +341,7 @@ class GLSDataCentre:
 			tempxml = string_decode(webresp.read())
 
 			filename = "%s%sGLSDataCenter.config" % (baseDir, osType.appDir)
-			outfile = open(filename, "w")
+			outfile = codecs.open(filename, "w", "utf-8")
 			outfile.write(tempxml)
 			outfile.close()
 
@@ -429,7 +430,7 @@ class Realm:
 			tempxml = string_decode(webresp.read())
 
 			filename = "%s%sserver.config" % (baseDir, osType.appDir)
-			outfile = open(filename, "w")
+			outfile = codecs.open(filename, "w", "utf-8")
 			outfile.write(tempxml)
 			outfile.close()
 
@@ -482,7 +483,7 @@ class WorldQueueConfig:
 			tempxml = string_decode(webresp.read())
 
 			filename = "%s%slauncher.config" % (baseDir, osType.appDir)
-			outfile = open(filename, "w")
+			outfile = codecs.open(filename, "w", "utf-8")
 			outfile.write(tempxml)
 			outfile.close()
 
@@ -526,6 +527,7 @@ class WorldQueueConfig:
 				self.loadSuccess = True
 		except:
 			self.loadSuccess = False
+			raise
 
 class Game:
 	def __init__(self, name, description):
@@ -568,7 +570,7 @@ xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\
 			tempxml = string_decode(webresp.read())
 
 			filename = "%s%sGLSAuthServer.config" % (baseDir, osType.appDir)
-			outfile = open(filename, "w")
+			outfile = codecs.open(filename, "w", "utf-8")
 			outfile.write(tempxml)
 			outfile.close()
 
@@ -634,7 +636,7 @@ class JoinWorldQueue:
 			tempxml = string_decode(webresp.read())
 
 			filename = "%s%sWorldQueue.config" % (baseDir, osType.appDir)
-			outfile = open(filename, "w")
+			outfile = codecs.open(filename, "w", "utf-8")
 			outfile.write(tempxml)
 			outfile.close()
 


### PR DESCRIPTION
I didn't test whether this would affect wine or not, but I don't want to take the chance.  In any case, Python 3's built-in open() writes files in the native codepage by default.  This works fine until you run into a character not supported in your native codepage, such as \ufeff (from the DDO world config) on cp1252 (the default for many Windows machines in the US), at which point Python (rightly) throws an exception.

This fixes that issue by creating a 'uopen' wrapper that points to open() on Python 2.x and codecs.open() on Python 3.x.  I tried just using codecs.open directly, but then Python 2.x throws an exception about converting ascii strings to unicode for it.